### PR TITLE
Add method to read from configuration file

### DIFF
--- a/app/src/main/java/com/example/codematchfrontend/GlobalUtils.java
+++ b/app/src/main/java/com/example/codematchfrontend/GlobalUtils.java
@@ -1,28 +1,32 @@
 package com.example.codematchfrontend;
 
+import android.content.Context;
+import android.content.res.Resources;
+
 import java.io.IOException;
 
 import okhttp3.OkHttpClient;
 
+class GlobalUtils {
+    private static final String TAG = GlobalUtils.class.getSimpleName();
+    static String BASE_URL;
+    static String API_KEY = "";
+    static String EMAIL = "";
+    static String FIREBASE_TOKEN = "";
+    static final OkHttpClient HTTP_CLIENT = new OkHttpClient();
 
-public class GlobalUtils {
-   /* static Helper getBASEID = new Helper();
-    public static String BASE_URL;
+    /**
+     * Initialize each configuration global variable by reading from the configuration file
+     * @param context Application context
+     * @throws Resources.NotFoundException Unable to find the config file
+     * @throws IOException Failed reading configuration file
+     */
+    static void initializeFromConfig(Context context)
+            throws Resources.NotFoundException, IOException {
+        BASE_URL = Helper.getConfigValue(context, "baseUrl");
+    }
 
-    static {
-        try {
-            BASE_URL = getBASEID.getPropValues();
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-    }*/
-    public static String BASE_URL = "https://cm.johnramsden.ca";
-
-    public static String API_KEY = "";
-    public static String EMAIL = "";
-    public static String FIREBASE_TOKEN = "";
-    public static OkHttpClient HTTP_CLIENT = new OkHttpClient();
-    public static int createID() {
+    static int createID() {
         int id = (int)System.currentTimeMillis();
         return id;
     }

--- a/app/src/main/java/com/example/codematchfrontend/Helper.java
+++ b/app/src/main/java/com/example/codematchfrontend/Helper.java
@@ -2,46 +2,31 @@ package com.example.codematchfrontend;
 
 import android.content.Context;
 import android.content.res.Resources;
-import android.util.Log;
-
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Date;
 import java.util.Properties;
 
-public final  class Helper {
-    String result = "";
-    InputStream inputStream;
+final class Helper {
 
-    public  String getPropValues() throws IOException {
+    /**
+     * Retrieve a configuration entry
+     * @param context Class context
+     * @param name Name of property being requested
+     * @return Property requested
+     * @throws Resources.NotFoundException
+     * @throws IOException
+     */
+    static String getConfigValue(Context context, String name)
+            throws Resources.NotFoundException, IOException {
 
-        try {
-            Properties prop = new Properties();
-            String propFileName = "config.properties";
+        // Retrieve raw resources
+        Resources resources = context.getResources();
+        InputStream rawResource = resources.openRawResource(R.raw.config);
 
-            inputStream = getClass().getClassLoader().getResourceAsStream(propFileName);
+        Properties properties = new Properties();
 
-            if (inputStream != null) {
-                prop.load(inputStream);
-            } else {
-                throw new FileNotFoundException("property file '" + propFileName + "' not found in the classpath");
-            }
-
-            Date time = new Date(System.currentTimeMillis());
-
-            // get the property value and print it out
-            String user = prop.getProperty("user");
-            //String company1 = prop.getProperty("company1");
-            //String company2 = prop.getProperty("company2");
-           // String company3 = prop.getProperty("company3");
-
-            result = "user";
-        } catch (Exception e) {
-            System.out.println("Exception: " + e);
-        } finally {
-            inputStream.close();
-        }
-        return result;
+        // Read raw config
+        properties.load(rawResource);
+        return properties.getProperty(name);
     }
 }

--- a/app/src/main/java/com/example/codematchfrontend/LoginView.java
+++ b/app/src/main/java/com/example/codematchfrontend/LoginView.java
@@ -15,6 +15,7 @@ import okhttp3.Response;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.content.Intent;
+import android.content.res.Resources;
 import android.os.Build;
 import android.os.Bundle;
 //import android.os.Handler;
@@ -39,21 +40,29 @@ import org.json.JSONObject;
 
 import java.io.IOException;
 
-
-
 public class LoginView extends AppCompatActivity {
     private String CHANNEL_ID = "1";
     private GoogleSignInClient mGoogleSignInClient;
 
-
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
+        try {
+            GlobalUtils.initializeFromConfig(this);
+        } catch (IOException e) {
+            /* TODO: Unable to find the config file or
+             *       Failed reading configuration file, exit in graceful manner
+             */
+            System.exit(1);
+        }
+
         createNotificationChannel();
 
         setContentView(R.layout.activity_login_view);
 
         SignInButton googleButton = findViewById(R.id.sign_in_button);
+
         googleButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {

--- a/app/src/main/res/raw/config.properties
+++ b/app/src/main/res/raw/config.properties
@@ -1,0 +1,2 @@
+# Default properties
+baseUrl="cm.johnramsden.ca"


### PR DESCRIPTION
Added method to read from `config.properties` file `app/src/main/res/raw/config.properties`

Added `GlobalUtils.initializeFromConfig` method to initialize the variables read from configuration file.

This initialize method should be called before using the variables need to be read from the configuration file, currently that is just `BASE_URL`, add additional variables to the `GlobalUtils.initializeFromConfig` if they should be read from the configuration file.

Currently it can are on two conditions:

```
@throws Resources.NotFoundException Unable to find the config file
@throws IOException Failed reading configuration file
```

Right now I set it to just exit the process in `LoginView.java`, I'm not sure if the error should be handled in another way.

If there is more than one possible entry point you'll need to initialize `GlobalUtils.initializeFromConfig` in each of them.