### PR TITLE
Place oauth in config.properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 private_key.pepk
 /.idea
 /keystore/upload-keystore.jks
+/app/src/main/res/raw/config.properties

--- a/app/src/main/java/com/example/codematchfrontend/GlobalUtils.java
+++ b/app/src/main/java/com/example/codematchfrontend/GlobalUtils.java
@@ -10,6 +10,7 @@ import okhttp3.OkHttpClient;
 class GlobalUtils {
     private static final String TAG = GlobalUtils.class.getSimpleName();
     static String BASE_URL;
+    static String OAUTH_CLIENT_SECRET;
     static String API_KEY = "";
     static String EMAIL = "";
     static String FIREBASE_TOKEN = "";
@@ -24,10 +25,10 @@ class GlobalUtils {
     static void initializeFromConfig(Context context)
             throws Resources.NotFoundException, IOException {
         BASE_URL = Helper.getConfigValue(context, "baseUrl");
+        OAUTH_CLIENT_SECRET = Helper.getConfigValue(context, "oauthClientSecret");
     }
 
     static int createID() {
-        int id = (int)System.currentTimeMillis();
-        return id;
+        return (int)System.currentTimeMillis();
     }
 }

--- a/app/src/main/java/com/example/codematchfrontend/LoginView.java
+++ b/app/src/main/java/com/example/codematchfrontend/LoginView.java
@@ -177,7 +177,7 @@ public class LoginView extends AppCompatActivity implements LocationListener {
         RequestBody requestBody = new FormBody.Builder()
                 .add("grant_type", "authorization_code")
                 .add("client_id", getString(R.string.default_web_client_id))
-                .add("client_secret", "mU5TklW6DA6gHyu0FOsehXnL")
+                .add("client_secret", GlobalUtils.OAUTH_CLIENT_SECRET)
                 .add("redirect_uri","")
                 .add("code", authcode)
                 .build();

--- a/app/src/main/res/raw/.keepme
+++ b/app/src/main/res/raw/.keepme
@@ -1,0 +1,1 @@
+oauthClientSecret=mU5TklW6DA6gHyu0FOsehXnL

--- a/app/src/main/res/raw/config.properties
+++ b/app/src/main/res/raw/config.properties
@@ -1,2 +1,0 @@
-# Default properties
-baseUrl=https://cm.johnramsden.ca/api

--- a/config.properties.example
+++ b/config.properties.example
@@ -1,0 +1,3 @@
+# Default properties
+baseUrl=https://cm.johnramsden.ca/api
+oauthClientSecret=REDACTED


### PR DESCRIPTION
Put oauth `client_secret` in configuration file.

Stop tracking the main configuration file since it contains secrets, instead add a example file to the root and place the active version in `app/src/main/res/raw/config.properties`